### PR TITLE
Reversed MockObject_Generator condition

### DIFF
--- a/src/shim.php
+++ b/src/shim.php
@@ -6,7 +6,7 @@ if (!class_exists('PHPUnit\Framework\TestCase') && class_exists('PHPUnit_Framewo
 if (!class_exists('PHPUnit\Runner\Version')) {
     class_alias('PHPUnit_Runner_Version', 'PHPUnit\Runner\Version');
 }
-if (!class_exists('PHPUnit\Framework\MockObject\Generator')) {
+if (class_exists('PHPUnit_Framework_MockObject_Generator')) {
     class_alias('PHPUnit_Framework_MockObject_Generator', 'PHPUnit\Framework\MockObject\Generator');
     class_alias('PHPUnit_Framework_MockObject_InvocationMocker', 'PHPUnit\Framework\MockObject\InvocationMocker');
     class_alias('PHPUnit_Framework_MockObject_Invokable', 'PHPUnit\Framework\MockObject\Invokable');


### PR DESCRIPTION
This change allows to use Codeception\Stub with my ZF1 projects (Zend_Loader raises fatal error if required file does not exist).
Stub::makeEmpty breaks code coverage in Codeception 2.4, so if this patch isn't merged, I won't be able to use Codeception 2.4

Codeception tests with this change passed: https://travis-ci.org/Codeception/Codeception/builds/365542285