### PR TITLE
Mark PHPUnit mandatory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,6 @@
         }
     },
     "require": {
-        "phpunit/phpunit-mock-objects": ">2.3 <7.0"
-    },
-    "require-dev": {
         "phpunit/phpunit": ">=4.8 <8.0"
     }
 }


### PR DESCRIPTION
Closes https://github.com/Codeception/Stub/issues/8

Requiring `phpunit/phpunit-mock-objects` forbids PHPUnit >= 7.2 since https://github.com/sebastianbergmann/phpunit/issues/3103

Since from PHPUnit 7.2 you will be able to use this library only with the entire PHPUnit library, but we also need backward compatibility, the unique way is to always require the full library.