### PR TITLE
Revert "Mark PHPUnit mandatory"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
         }
     },
     "require": {
+        "phpunit/phpunit-mock-objects": ">2.3 <7.0"
+    },
+    "require-dev": {
         "phpunit/phpunit": ">=4.8 <8.0"
     }
 }


### PR DESCRIPTION
Reverts Codeception/Stub#9

Because there are more incompatibilities with PhpUnit 7.2 in Codeception/Codeception: https://github.com/Codeception/Codeception/issues/5092