### PR TITLE
Compatibility with PHPUnit 8.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 7
-  - 7.1
   - 7.2
   - 7.3
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     },
     "require": {
-        "codeception/phpunit-wrapper": "^6.6.1 | ^7.7.1 | ^8.0.3",
-        "phpunit/phpunit": ">=6.5 <9.0"
+        "codeception/phpunit-wrapper": "^8.0.4",
+        "phpunit/phpunit": "^8.4"
     }
 }

--- a/src/Stub.php
+++ b/src/Stub.php
@@ -4,7 +4,7 @@ namespace Codeception;
 use Codeception\Stub\ConsecutiveMap;
 use Codeception\Stub\StubMarshaler;
 use PHPUnit\Framework\MockObject\Generator;
-use PHPUnit\Framework\MockObject\Matcher\AnyInvokedCount;
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use PHPUnit\Framework\MockObject\Stub\ConsecutiveCalls;
 use PHPUnit\Framework\MockObject\Stub\ReturnCallback;
 use PHPUnit\Framework\MockObject\Stub\ReturnStub;

--- a/src/Stub/Expected.php
+++ b/src/Stub/Expected.php
@@ -2,8 +2,8 @@
 
 namespace Codeception\Stub;
 
-use PHPUnit\Framework\MockObject\Matcher\InvokedAtLeastOnce;
-use PHPUnit\Framework\MockObject\Matcher\InvokedCount;
+use PHPUnit\Framework\MockObject\Rule\InvokedAtLeastOnce;
+use PHPUnit\Framework\MockObject\Rule\InvokedCount;
 
 class Expected
 {

--- a/src/Stub/StubMarshaler.php
+++ b/src/Stub/StubMarshaler.php
@@ -2,7 +2,7 @@
 
 namespace Codeception\Stub;
 
-use PHPUnit\Framework\MockObject\Matcher\InvokedRecorder;
+use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 
 /**
  * Holds matcher and value of mocked method
@@ -13,7 +13,7 @@ class StubMarshaler
 
     private $methodValue;
 
-    public function __construct(InvokedRecorder $matcher, $value)
+    public function __construct(InvocationOrder $matcher, $value)
     {
         $this->methodMatcher = $matcher;
         $this->methodValue = $value;


### PR DESCRIPTION
Sets lowest supported version of PHPUnit to 8.4 too.
Replaces #19