### PR TITLE
Support for argument expectations in Stubs

### DIFF
--- a/src/Stub.php
+++ b/src/Stub.php
@@ -583,10 +583,19 @@ class Stub
             if ($reflectionClass->hasMethod($param)) {
                 if ($value instanceof StubMarshaler) {
                     $marshaler = $value;
-                    $mock
-                        ->expects($marshaler->getMatcher())
-                        ->method($param)
-                        ->will(new ReturnCallback($marshaler->getValue()));
+                    $methodArguments = $marshaler->getArguments();
+                    if ($methodArguments !== null) {
+                        $mock
+                            ->expects($marshaler->getMatcher())
+                            ->method($param)
+                            ->with(...$methodArguments)
+                            ->will(new ReturnCallback($marshaler->getValue()));
+                    } else {
+                        $mock
+                            ->expects($marshaler->getMatcher())
+                            ->method($param)
+                            ->will(new ReturnCallback($marshaler->getValue()));
+                    }
                 } elseif ($value instanceof \Closure) {
                     $mock
                         ->expects(new AnyInvokedCount)

--- a/src/Stub/StubMarshaler.php
+++ b/src/Stub/StubMarshaler.php
@@ -13,6 +13,8 @@ class StubMarshaler
 
     private $methodValue;
 
+    private $methodArguments = null;
+
     public function __construct(InvocationOrder $matcher, $value)
     {
         $this->methodMatcher = $matcher;
@@ -27,5 +29,17 @@ class StubMarshaler
     public function getValue()
     {
         return $this->methodValue;
+    }
+
+    public function getArguments()
+    {
+        return $this->methodArguments;
+    }
+
+    public function with(...$arguments)
+    {
+        $this->methodArguments = $arguments;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Basic support for argument expectactions in Stubs, by chaining a with() method to Expected. This is something we were really missing compared to plain PHPUnit mocks, and turned out to be not that hard to add.

Syntax: Stub\Expected::once()->with('argument', 1, new StdClass)

Fully backwards compatible and unit tests have been added