### PR TITLE
docs: Typo in Stub.md

### DIFF
--- a/docs/Stub.md
+++ b/docs/Stub.md
@@ -178,7 +178,7 @@ Accepts either name of class or object of that class
 
 ``` php
 <?php
-Stub::construct(new User, ['autosave' => false), ['name' => 'davert']);
+Stub::construct(new User, ['autosave' => false], ['name' => 'davert']);
 ?>
 ```
 


### PR DESCRIPTION
Hello.

Theres is a little typo in on line 181 of `Stub.md` file, just replaced a parenthesis with a bracket.