### PR TITLE
Don't add dynamic property __mocked to mocked object

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
     },
     "require-dev": {
         "consolidation/robo": "^3.0"
+    },
+    "conflict": {
+        "codeception/codeception": "<5.0.6"
     }
 }

--- a/src/Stub.php
+++ b/src/Stub.php
@@ -92,17 +92,6 @@ class Stub
 
         self::bindParameters($mock, $params);
 
-        return self::markAsMock($mock, $reflection);
-    }
-
-    /**
-     * Set __mock flag, if at all possible
-     */
-    private static function markAsMock(object $mock, ReflectionClass $reflection): object
-    {
-        if (!$reflection->hasMethod('__set')) {
-            $mock->__mocked = $reflection->getName();
-        }
         return $mock;
     }
 
@@ -169,11 +158,11 @@ class Stub
      */
     public static function makeEmptyExcept($class, string $method, array $params = [], $testCase = false)
     {
-        [$class, $reflectionClass, $methods] = self::createEmpty($class, $method);
+        [$class, $methods] = self::createEmpty($class, $method);
         $mock = self::generateMock($class, $methods, [], '', false, $testCase);
         self::bindParameters($mock, $params);
 
-        return self::markAsMock($mock, $reflectionClass);
+        return $mock;
     }
 
     /**
@@ -223,17 +212,14 @@ class Stub
     public static function makeEmpty($class, array $params = [], $testCase = false)
     {
         $class = self::getClassname($class);
-        $reflection = new ReflectionClass($class);
-
-        $methods = get_class_methods($class);
         $methods = array_filter(
-            $methods,
+            get_class_methods($class),
             fn($i) => !in_array($i, Stub::$magicMethods)
         );
         $mock = self::generateMock($class, $methods, [], '', false, $testCase);
         self::bindParameters($mock, $params);
 
-        return self::markAsMock($mock, $reflection);
+        return $mock;
     }
 
     /**
@@ -307,7 +293,7 @@ class Stub
         $mock = self::generateMock($class, $arguments, $constructorParams, $testCase);
         self::bindParameters($mock, $params);
 
-        return self::markAsMock($mock, $reflection);
+        return $mock;
     }
 
     /**
@@ -354,22 +340,18 @@ class Stub
      * @param bool|PHPUnitTestCase $testCase
      *
      * @return PHPUnitMockObject&RealInstanceType
-     * @throws ReflectionException
      */
     public static function constructEmpty($class, array $constructorParams = [], array $params = [], $testCase = false)
     {
         $class = self::getClassname($class);
-        $reflection = new ReflectionClass($class);
-
-        $methods = get_class_methods($class);
         $methods = array_filter(
-            $methods,
+            get_class_methods($class),
             fn($i) => !in_array($i, Stub::$magicMethods)
         );
         $mock = self::generateMock($class, $methods, $constructorParams, $testCase);
         self::bindParameters($mock, $params);
 
-        return self::markAsMock($mock, $reflection);
+        return $mock;
     }
 
     /**
@@ -423,11 +405,11 @@ class Stub
         array $params = [],
         $testCase = false
     ) {
-        [$class, $reflectionClass, $methods] = self::createEmpty($class, $method);
+        [$class, $methods] = self::createEmpty($class, $method);
         $mock = self::generateMock($class, $methods, $constructorParams, $testCase);
         self::bindParameters($mock, $params);
 
-        return self::markAsMock($mock, $reflectionClass);
+        return $mock;
     }
 
     private static function generateMock()
@@ -633,6 +615,6 @@ class Stub
         );
 
         $methods = count($methods) ? $methods : null;
-        return [$class, $reflectionClass, $methods];
+        return [$class, $methods];
     }
 }

--- a/src/Test/Feature/Stub.php
+++ b/src/Test/Feature/Stub.php
@@ -290,6 +290,7 @@ trait Stub
      * @template RealInstanceType of object
      * @param class-string<RealInstanceType>|RealInstanceType|callable(): class-string<RealInstanceType> $class - A class to be mocked
      * @return MockObject&RealInstanceType
+     * @throws \ReflectionException
      */
     public function constructEmptyExcept($class, string $method, array $constructorParams = [], array $params = [])
     {

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -160,42 +160,42 @@ final class StubTest extends TestCase
             $dummy
         );
         $dummy = Stub::make(new DummyOverloadableClass());
-        $this->assertObjectHasProperty('__mocked', $dummy);
+        $this->assertSame(DummyOverloadableClass::class, get_parent_class($dummy));
         $dummy = Stub::makeEmpty(new DummyClass());
         $this->assertInstanceOf(
             MockObject::class,
             $dummy
         );
         $dummy = Stub::makeEmpty(new DummyOverloadableClass());
-        $this->assertObjectHasProperty('__mocked', $dummy);
+        $this->assertSame(DummyOverloadableClass::class, get_parent_class($dummy));
         $dummy = Stub::makeEmptyExcept(new DummyClass(), 'helloWorld');
         $this->assertInstanceOf(
             MockObject::class,
             $dummy
         );
         $dummy = Stub::makeEmptyExcept(new DummyOverloadableClass(), 'helloWorld');
-        $this->assertObjectHasProperty('__mocked', $dummy);
+        $this->assertSame(DummyOverloadableClass::class, get_parent_class($dummy));
         $dummy = Stub::construct(new DummyClass());
         $this->assertInstanceOf(
             MockObject::class,
             $dummy
         );
         $dummy = Stub::construct(new DummyOverloadableClass());
-        $this->assertObjectHasProperty('__mocked', $dummy);
+        $this->assertSame(DummyOverloadableClass::class, get_parent_class($dummy));
         $dummy = Stub::constructEmpty(new DummyClass());
         $this->assertInstanceOf(
             MockObject::class,
             $dummy
         );
         $dummy = Stub::constructEmpty(new DummyOverloadableClass());
-        $this->assertObjectHasProperty('__mocked', $dummy);
+        $this->assertSame(DummyOverloadableClass::class, get_parent_class($dummy));
         $dummy = Stub::constructEmptyExcept(new DummyClass(), 'helloWorld');
         $this->assertInstanceOf(
             MockObject::class,
             $dummy
         );
         $dummy = Stub::constructEmptyExcept(new DummyOverloadableClass(), 'helloWorld');
-        $this->assertObjectHasProperty('__mocked', $dummy);
+        $this->assertSame(DummyOverloadableClass::class, get_parent_class($dummy));
     }
 
     protected function assertMethodReplaced($dummy)


### PR DESCRIPTION
Because setting dynamic properties is deprecated since PHP 8.2