### PR TITLE
Improve error message if an abstract class is mocked in PHPUnit 12

### DIFF
--- a/src/Stub.php
+++ b/src/Stub.php
@@ -462,6 +462,10 @@ class Stub
             $methodName = $isAbstract ? 'getMockForAbstractClass' : 'getMock';
         }
 
+        if ($isAbstract && version_compare(PHPUnitVersion::series(), '12', '>=')) {
+            throw new RuntimeException('PHPUnit 12 or greater does not allow to mock abstract classes anymore');
+        }
+
         // PHPUnit 10.3 changed the namespace
         if (version_compare(PHPUnitVersion::series(), '10.3', '>=')) {
             $generatorClass = new Generator();

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -19,6 +19,7 @@ final class StubTest extends TestCase
 
     public function setUp(): void
     {
+        require_once $file = __DIR__. '/_data/DummyAbstractClass.php';
         require_once $file = __DIR__. '/_data/DummyOverloadableClass.php';
         require_once $file = __DIR__. '/_data/DummyClass.php';
         $this->dummy = new DummyClass(true);
@@ -403,6 +404,17 @@ final class StubTest extends TestCase
     {
         $stub = Stub::makeEmpty(Countable::class, ['count' => 5]);
         $this->assertEquals(5, $stub->count());
+    }
+
+    public function testStubMakeEmptyAbstractClass()
+    {
+        if (version_compare(PHPUnitVersion::id(), '12', '>=')) {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('PHPUnit 12 or greater does not allow to mock abstract classes anymore');
+        }
+
+        $stub = Stub::make('DummyAbstractClass');
+        $this->assertInstanceOf('DummyAbstractClass', $stub);
     }
 }
 

--- a/tests/_data/DummyAbstractClass.php
+++ b/tests/_data/DummyAbstractClass.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+abstract class DummyAbstractClass
+{
+}


### PR DESCRIPTION
PHPUnit 12 removed the possibility to mock abstract classes (https://github.com/sebastianbergmann/phpunit/issues/5314)

I noticed a quite cryptic error message if I try to mock an abstract class:
>  call_user_func_array(): Argument #1 ($callback) must be a valid callback, class PHPUnit\Framework\MockObject\Generator\Generator does not have a method "mockObjectForAbstractClass"

With this PR the error message will be "PHPUnit 12 or greater does not allow to mock abstract classes anymore".