### PR TITLE
Fix number of arguments used in tests

### DIFF
--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -274,11 +274,11 @@ final class StubTest extends TestCase
             [1, Stub\Expected::once()],
             [2, Stub\Expected::atLeastOnce()],
             [3, Stub\Expected::exactly(3)],
-            [1, Stub\Expected::once(fn(): bool => true), true],
-            [2, Stub\Expected::atLeastOnce(fn(): array => []), []],
-            [1, Stub\Expected::exactly(1, fn() => null), null],
-            [1, Stub\Expected::exactly(1, fn(): string => 'hello world!'), 'hello world!'],
-            [1, Stub\Expected::exactly(1, 'hello world!'), 'hello world!'],
+            [1, Stub\Expected::once(fn(): bool => true)],
+            [2, Stub\Expected::atLeastOnce(fn(): array => [])],
+            [1, Stub\Expected::exactly(1, fn() => null)],
+            [1, Stub\Expected::exactly(1, fn(): string => 'hello world!')],
+            [1, Stub\Expected::exactly(1, 'hello world!')],
         ];
     }
 


### PR DESCRIPTION
This fixes warnings like this e.g. if tests are executed with PHP 8.4:

> 1) StubTest::testMethodMatcherWithMakeEmpty
> * Data set `#4` provided by StubTest::matcherProvider has more arguments (3) than the test method accepts (2)
> 
> * Data set `#5` provided by StubTest::matcherProvider has more arguments (3) than the test method accepts (2)
> 
> * Data set `#6` provided by StubTest::matcherProvider has more arguments (3) than the test method accepts (2)
> 
> * Data set `#7` provided by StubTest::matcherProvider has more arguments (3) than the test method accepts (2)
> 
> * Data set `#8` provided by StubTest::matcherProvider has more arguments (3) than the test method accepts (2)
> 
> /var/www/html/tests/StubTest.php:30