### PR TITLE
Remove Reflection*::setAccessible() calls + drop PHP < 8.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
+        php: [8.1, 8.2, 8.3, 8.4]
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     },
     "require": {
-        "php": "^7.4 | ^8.0",
+        "php": "^8.1",
         "phpunit/phpunit": "^8.4 | ^9.0 | ^10.0 | ^11 | ^12"
     },
     "require-dev": {

--- a/src/Stub.php
+++ b/src/Stub.php
@@ -550,7 +550,6 @@ class Stub
                 }
             } elseif ($reflectionClass->hasProperty($param)) {
                 $reflectionProperty = $reflectionClass->getProperty($param);
-                $reflectionProperty->setAccessible(true);
                 $reflectionProperty->setValue($mock, $value);
             } else {
                 if ($reflectionClass->hasMethod('__set')) {

--- a/tests/ResetMocks.php
+++ b/tests/ResetMocks.php
@@ -11,7 +11,6 @@ trait ResetMocks
             $refl = $refl->getParentClass();
         }
         $prop = $refl->getProperty('mockObjects');
-        $prop->setAccessible(true);
         $prop->setValue($this, array());
     }
 }


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations

This PR drops support for PHP < 8.1.
Thus, the calls can be safely removed.